### PR TITLE
Avoid a warning in covid_trends_job.py

### DIFF
--- a/jobs/covid_trends_job.py
+++ b/jobs/covid_trends_job.py
@@ -9,7 +9,7 @@ from pyspark.sql import SparkSession
 from covid_analysis.transforms import *
 
 # tell Python the type of the spark global so code completion works
-spark: SparkSession = spark
+spark: SparkSession = spark # type: ignore
 
 # check if job is running in production mode
 is_prod = len(sys.argv) >= 2 and sys.argv[1] == "--prod"


### PR DESCRIPTION
Using a PEP 484 "# type: ignore" annotation