### PR TITLE
Don't use global spark

### DIFF
--- a/jobs/covid_trends_job.py
+++ b/jobs/covid_trends_job.py
@@ -8,8 +8,7 @@ from pyspark.sql import SparkSession
 
 from covid_analysis.transforms import *
 
-# tell Python the type of the spark global so code completion works
-spark: SparkSession = spark
+spark = SparkSession.builder.getOrCreate()
 
 # check if job is running in production mode
 is_prod = len(sys.argv) >= 2 and sys.argv[1] == "--prod"


### PR DESCRIPTION
Don't use spark global because IDE code completion doesn't work with unknown globals.